### PR TITLE
Add star prompt and scroll behaviour

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -329,6 +329,18 @@
       margin-top: 5px;
       text-align: right;
     }
+    /* Star Prompt Styles */
+    #starPrompt {
+      display: none;
+      border: 1px solid var(--md-sys-color-outline);
+      padding: 15px;
+      border-radius: 6px;
+      margin-top: 20px;
+      background-color: var(--md-sys-color-surface-container-low);
+    }
+    #starPrompt button {
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>
@@ -418,6 +430,12 @@
   <div id="tokenCount" class="info-display" style="display:none;"></div>
 
   <div id="summaryPreview" style="display:none;"></div>
+
+  <div id="starPrompt">
+    <p>If you enjoy this extension, please consider starring the project on GitHub.</p>
+    <button id="starRepoBtn">Star on GitHub</button>
+    <button id="dismissStarPromptBtn">Dismiss</button>
+  </div>
 
   <!-- Feedback Section -->
   <div id="feedbackSection">


### PR DESCRIPTION
## Summary
- show star prompt for repo after copying summary
- allow starring the repo with GitHub token or open repo page
- smooth scroll to top after copy

## Testing
- `npm test` *(fails: could not find package.json)*
- `npx eslint .` *(fails: couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68530c9e4e04832d9bfdef345d2ab157