### PR TITLE
Add Hebrew, Chinese, and Arabic locales

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,0 +1,4 @@
+{
+  "extensionName": {"message": "ملخص مستودعات GitHub"},
+  "extensionDescription": {"message": "إنشاء ملخصات للشفرة وتنزيل مستودعات GitHub."}
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,4 @@
+{
+  "extensionName": {"message": "GitHub Repo Summarizer"},
+  "extensionDescription": {"message": "Generate code summaries and download GitHub repositories."}
+}

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -1,0 +1,4 @@
+{
+  "extensionName": {"message": "מסכם מאגרי GitHub"},
+  "extensionDescription": {"message": "יצירת תקצירי קוד והורדת מאגרי GitHub."}
+}

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,4 @@
+{
+  "extensionName": {"message": "GitHub 仓库摘要工具"},
+  "extensionDescription": {"message": "生成代码摘要并下载GitHub仓库."}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "GitHub Repo Summarizer",
+  "default_locale": "en",
+  "name": "__MSG_extensionName__",
   "version": "1.4.2",
-  "description": "Generate code summaries and download GitHub repositories.",
+  "description": "__MSG_extensionDescription__",
   "permissions": ["activeTab", "storage"],
   "host_permissions": [
     "https://api.github.com/repos/*/*",
@@ -21,6 +22,6 @@
       "128": "icons/icon128.png"
     },
     "default_popup": "popup.html",
-    "default_title": "GitHub Repo Summarizer"
+    "default_title": "__MSG_extensionName__"
   }
 }


### PR DESCRIPTION
## Summary
- add localization placeholders in `manifest.json`
- provide English messages file
- add Hebrew, Chinese (Simplified), and Arabic translations

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d3359c71c832daf0c7ee32f1a880b