### PR TITLE
Add privacy policy document

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,15 @@
+# Privacy Policy
+
+This extension operates entirely within your browser. It does not send any data to external servers other than the GitHub API when you request repository information.
+
+## Data Stored Locally
+
+- **GitHub Personal Access Token**: If you provide a token, it is saved using Chrome's `storage.local` so you don't need to re-enter it. The token is only used to authenticate requests to the GitHub API.
+- **Repository Settings**: If you enable the *Save Settings* option, your selected directories, file extensions, and other preferences are stored in Chrome's `storage.local` under a key specific to each repository.
+
+All information stored by the extension stays on your machine. You can remove it at any time by clearing the extension's data or deleting the token and saved settings through the popup interface.
+
+## Data Usage
+
+Stored data is used solely to make authenticated requests to the GitHub API and to restore your preferences. The extension does not collect analytics or share your data with any third party.
+

--- a/README.md
+++ b/README.md
@@ -201,4 +201,8 @@ Contributions are welcome! Please follow these steps:
 
 Your feedback is invaluable to us! If you have any suggestions, feature requests, or encounter any issues, please use the **Feedback Section** within the extension popup to share your thoughts. We strive to make the **GitHub Repo Summarizer** better with each update.
 
+## Privacy
+
+See [PRIVACY.md](PRIVACY.md) for details on what data the extension stores and how it is handled.
+
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "name": "__MSG_extensionName__",
   "version": "1.4.2",
   "description": "__MSG_extensionDescription__",
+  "homepage_url": "https://github.com/zack-dev-cm/github-repo-sum-chrome-plugin/blob/main/PRIVACY.md",
   "permissions": ["activeTab", "storage"],
   "host_permissions": [
     "https://api.github.com/repos/*/*",


### PR DESCRIPTION
## Summary
- document stored data in `PRIVACY.md`
- link to the privacy policy from the README
- add `homepage_url` field in the extension manifest

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c0c7958832d9ead8672f5327245