### PR TITLE
Add Puppeteer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@
 
    - After making changes, go to `chrome://extensions/`, find the extension, and click **Reload**.
 
+### Running Tests
+
+End-to-end tests rely on [Puppeteer](https://pptr.dev/). Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test
+```
+
 ### Contributing
 
 Contributions are welcome! Please follow these steps:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "github-repo-sum-chrome-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node tests/e2e/basic.test.js"
+  },
+  "devDependencies": {
+    "puppeteer": "^21.6.0"
+  }
+}

--- a/tests/e2e/basic.test.js
+++ b/tests/e2e/basic.test.js
@@ -1,0 +1,52 @@
+import puppeteer from 'puppeteer';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+(async () => {
+  const extensionPath = path.resolve(__dirname, '../../');
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--ignore-certificate-errors',
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  const repoPage = await browser.newPage();
+  await repoPage.goto('https://github.com/octocat/Hello-World');
+
+  const extensionTarget = await browser.waitForTarget(t => t.type() === 'service_worker');
+  const extensionUrl = extensionTarget.url();
+  const [, , extensionId] = extensionUrl.split('/');
+
+  const popupPage = await browser.newPage();
+  await popupPage.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  // Activate repo page so chrome.tabs.query returns it as the active tab
+  await repoPage.bringToFront();
+
+  // Set default options
+  await popupPage.evaluate(() => {
+    document.getElementById('extensions').value = '.md';
+  });
+
+  await popupPage.evaluate(() => {
+    document.getElementById('summarizeBtn').click();
+  });
+
+  await popupPage.waitForSelector('#summaryPreview', { visible: true, timeout: 60000 });
+  const summaryText = await popupPage.$eval('#summaryPreview', el => el.textContent.trim());
+
+  if (!summaryText.length) {
+    console.error('Summary is empty');
+    process.exit(1);
+  }
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add a `package.json` with Puppeteer as a dev dependency
- create an end-to-end Puppeteer test
- document running tests

## Testing
- `npm test` *(fails: Timed out after waiting 30000ms)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c120484832dae43ea73dd81a7c1