### PR TITLE
Add OAuth service worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,51 @@
+// background.js (service worker)
+
+/**
+ * Listen for messages requesting a GitHub OAuth token.
+ */
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'getGithubToken') {
+    fetchGithubToken().then(token => {
+      sendResponse({ token });
+    }).catch(err => {
+      sendResponse({ error: err.toString() });
+    });
+    return true; // Indicates async response
+  }
+});
+
+/**
+ * Launches the GitHub OAuth flow using chrome.identity.
+ * This example expects the user to authenticate via Google on GitHub's sign-in page.
+ */
+function fetchGithubToken() {
+  return new Promise((resolve, reject) => {
+    const clientId = 'YOUR_GITHUB_CLIENT_ID';
+    const redirectUri = chrome.identity.getRedirectURL('github');
+    const authUrl =
+      `https://github.com/login/oauth/authorize?client_id=${clientId}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&scope=repo&response_type=token`;
+
+    chrome.identity.launchWebAuthFlow(
+      { url: authUrl, interactive: true },
+      responseUrl => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+        if (responseUrl) {
+          const params = new URL(responseUrl).hash.substring(1);
+          const token = new URLSearchParams(params).get('access_token');
+          if (token) {
+            resolve(token);
+          } else {
+            reject('No access token found');
+          }
+        } else {
+          reject('No response from OAuth');
+        }
+      }
+    );
+  });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "version": "1.4.2",
   "description": "__MSG_extensionDescription__",
-  "permissions": ["activeTab", "storage"],
+  "permissions": ["activeTab", "storage", "identity"],
   "host_permissions": [
     "https://api.github.com/repos/*/*",
     "https://api.github.com/repos/*/*/git/trees/*",
@@ -15,6 +15,9 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",
@@ -23,5 +26,11 @@
     },
     "default_popup": "popup.html",
     "default_title": "__MSG_extensionName__"
+  },
+  "oauth2": {
+    "client_id": "YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com",
+    "scopes": [
+      "https://www.googleapis.com/auth/userinfo.email"
+    ]
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -402,6 +402,13 @@
     <input type="password" id="token" placeholder="GitHub Token">
   </div>
   <div class="form-group">
+    <label>
+      <input type="checkbox" id="useGoogleAuth">
+      Use Google Sign-In
+    </label>
+    <button id="googleSignInBtn" style="display:none; margin-top:10px;">Sign in with Google</button>
+  </div>
+  <div class="form-group">
     <label for="commit">Commit SHA or Branch (optional):</label>
     <input type="text" id="commit" placeholder="e.g., main or a1b2c3d">
     <select id="commitDropdown"></select>

--- a/popup.js
+++ b/popup.js
@@ -18,11 +18,16 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('preScanBtn').addEventListener('click', preScanRepo);
   document.getElementById('submitFeedbackBtn').addEventListener('click', submitFeedback);
   document.getElementById('copySummaryBtn').addEventListener('click', copySummaryToClipboard);
+  document.getElementById('useGoogleAuth').addEventListener('change', toggleAuthMethod);
+  document.getElementById('googleSignInBtn').addEventListener('click', signInWithGoogle);
   const starBtn = document.getElementById('starRepoBtn');
   if (starBtn) starBtn.addEventListener('click', starRepo);
   const dismissBtn = document.getElementById('dismissStarPromptBtn');
   if (dismissBtn) dismissBtn.addEventListener('click', dismissStarPrompt);
   displayAppVersion(); // Display app version on load
+
+  // Initialize auth method UI
+  toggleAuthMethod();
 
   // Directory Controls
   document.getElementById('directorySearch').addEventListener('input', filterDirectories);
@@ -67,6 +72,31 @@ function loadToken() {
 function saveToken(token) {
   chrome.storage.local.set({ 'githubToken': token }, () => {
     console.log('GitHub token saved.');
+  });
+}
+
+/**
+ * Toggle between manual token entry and Google sign-in.
+ */
+function toggleAuthMethod() {
+  const useGoogle = document.getElementById('useGoogleAuth').checked;
+  document.getElementById('token').style.display = useGoogle ? 'none' : 'block';
+  document.getElementById('googleSignInBtn').style.display = useGoogle ? 'block' : 'none';
+}
+
+/**
+ * Request a GitHub OAuth token via the background service worker.
+ */
+function signInWithGoogle() {
+  chrome.runtime.sendMessage({ action: 'getGithubToken' }, response => {
+    if (response && response.token) {
+      document.getElementById('token').value = response.token;
+      saveToken(response.token);
+      displayStatus('GitHub token acquired via Google sign-in.');
+    } else {
+      const err = (response && response.error) || 'Authentication failed';
+      displayError(err);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- implement background.js service worker using `chrome.identity`
- enable OAuth scopes and service worker in manifest
- add Google sign-in toggle and button to popup
- toggle between manual token entry and Google sign-in in popup.js

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c15a5c4832d927e145410afbe8d