### PR TITLE
Add OAuth service worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,38 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'oauth') {
+    const clientId = 'YOUR_GITHUB_CLIENT_ID';
+    const clientSecret = 'YOUR_GITHUB_CLIENT_SECRET';
+    const redirectUri = chrome.identity.getRedirectURL();
+    const authUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo`;
+    chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true }, (redirect) => {
+      if (chrome.runtime.lastError || !redirect) {
+        sendResponse({ error: chrome.runtime.lastError?.message || 'OAuth failed' });
+        return;
+      }
+      const url = new URL(redirect);
+      const code = url.searchParams.get('code');
+      if (!code) {
+        sendResponse({ error: 'No code returned' });
+        return;
+      }
+      fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code })
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (data.access_token) {
+            sendResponse({ token: data.access_token });
+          } else {
+            sendResponse({ error: 'No access token' });
+          }
+        })
+        .catch(err => sendResponse({ error: err.toString() }));
+    });
+    return true;
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -5,12 +5,20 @@
   "version": "1.4.2",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/zack-dev-cm/github-repo-sum-chrome-plugin/blob/main/PRIVACY.md",
-  "permissions": ["activeTab", "storage"],
+  "permissions": ["activeTab", "storage", "identity"],
   "host_permissions": [
     "https://api.github.com/repos/*/*",
     "https://api.github.com/repos/*/*/git/trees/*",
-    "https://api.github.com/repos/*/*/git/blobs/*"
+    "https://api.github.com/repos/*/*/git/blobs/*",
+    "https://github.com/login/oauth/*"
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "oauth2": {
+    "client_id": "YOUR_GOOGLE_CLIENT_ID",
+    "scopes": ["https://www.googleapis.com/auth/userinfo.email"]
+  },
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/popup.html
+++ b/popup.html
@@ -398,9 +398,17 @@
   </div>
 
   <div class="form-group">
+    <label for="authMethod">Authentication Method:</label>
+    <select id="authMethod">
+      <option value="manual" selected>Manual Token</option>
+      <option value="google">Google Sign-In</option>
+    </select>
+  </div>
+  <div class="form-group" id="manualTokenGroup">
     <label for="token">GitHub Token (optional):</label>
     <input type="password" id="token" placeholder="GitHub Token">
   </div>
+  <button id="googleSignInBtn" style="display:none;">Sign in with Google</button>
   <div class="form-group">
     <label for="commit">Commit SHA or Branch (optional):</label>
     <input type="text" id="commit" placeholder="e.g., main or a1b2c3d">

--- a/popup.js
+++ b/popup.js
@@ -33,6 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('token').addEventListener('input', (e) => {
     saveToken(e.target.value.trim());
   });
+
+  document.getElementById('authMethod').addEventListener('change', toggleAuthMethod);
+  const googleBtn = document.getElementById('googleSignInBtn');
+  if (googleBtn) googleBtn.addEventListener('click', signInWithGoogle);
+  toggleAuthMethod();
 });
 
 /**
@@ -1178,5 +1183,34 @@ function displayStatus(message) {
   loadingEl.style.display = 'none';
   errorEl.style.display = 'none';
   statusEl.textContent = message;
-  statusEl.style.display = 'block';
+  statusEl.style.display = 'block';}
+/**
+ * Toggle authentication method between manual token and Google sign-in.
+ */
+function toggleAuthMethod() {
+  const method = document.getElementById('authMethod').value;
+  const manualGroup = document.getElementById('manualTokenGroup');
+  const googleBtn = document.getElementById('googleSignInBtn');
+  if (method === 'google') {
+    manualGroup.style.display = 'none';
+    googleBtn.style.display = 'block';
+  } else {
+    manualGroup.style.display = 'block';
+    googleBtn.style.display = 'none';
+  }
 }
+
+/**
+ * Initiate Google sign-in to retrieve a GitHub OAuth token.
+ */
+function signInWithGoogle() {
+  chrome.runtime.sendMessage({ type: 'oauth' }, (response) => {
+    if (response && response.token) {
+      document.getElementById('token').value = response.token;
+      saveToken(response.token);
+    } else if (response && response.error) {
+      displayError('OAuth failed: ' + response.error);
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement OAuth flow in a new background.js service worker
- update manifest with OAuth scopes and service worker
- add authentication method toggle in popup.html
- handle Google sign-in via chrome.identity in popup.js

## Testing
- `npm install`
- `node tests/e2e/basic.test.js` *(fails: Target closed)*

------
https://chatgpt.com/codex/tasks/task_b_686d3f0f9860832d8508fb5e64945601