### PR TITLE
Add extension URLs and bump version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,9 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extensionName__",
-  "version": "1.4.2",
+  "version": "1.4.3",
+  "homepage_url": "https://github.com/zack-dev-cm/github-repo-sum-chrome-plugin",
+  "support_url": "https://github.com/zack-dev-cm/github-repo-sum-chrome-plugin/issues",
   "description": "__MSG_extensionDescription__",
   "permissions": ["activeTab", "storage"],
   "host_permissions": [


### PR DESCRIPTION
## Summary
- add `homepage_url` and `support_url` to manifest
- bump manifest version to 1.4.3

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c7dd980832db99e666d960cd6dc