### PR TITLE
Add token clear functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - **Code Summarization**: Extracts comments and function definitions from code files.
 - **Customizable File Types**: Supports a wide range of programming languages.
 - **GitHub API Integration**: Fetches repository data using the GitHub API.
-- **Personal Access Token Support**: Optionally use your GitHub token to increase API rate limits.
+- **Personal Access Token Support**: Optionally use your GitHub token to increase API rate limits and clear it at any time with the **Clear Token** button.
 - **Autoscrolling**: Automatically scrolls the popup window to display the summary immediately after generation.
 - **User Feedback Collection**: Provides a feedback form for users to suggest new features or report issues.
 
@@ -53,6 +53,7 @@
    - In the popup window, you can pick a commit from the dropdown or specify a branch name.
    - Click the **Summarize Repository** button to generate the summary.
    - Optionally, enter your GitHub Personal Access Token for higher rate limits.
+   - Click **Clear Token** in the popup to remove a stored token when you're done.
 
 4. **View the Summary**:
 

--- a/popup.html
+++ b/popup.html
@@ -400,6 +400,7 @@
   <div class="form-group">
     <label for="token">GitHub Token (optional):</label>
     <input type="password" id="token" placeholder="GitHub Token">
+    <button id="clearTokenBtn" type="button">Clear Token</button>
   </div>
   <div class="form-group">
     <label for="commit">Commit SHA or Branch (optional):</label>

--- a/popup.js
+++ b/popup.js
@@ -33,6 +33,10 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('token').addEventListener('input', (e) => {
     saveToken(e.target.value.trim());
   });
+
+  // Clear stored GitHub token when clear button is clicked
+  const clearTokenBtn = document.getElementById('clearTokenBtn');
+  if (clearTokenBtn) clearTokenBtn.addEventListener('click', clearToken);
 });
 
 /**
@@ -67,6 +71,16 @@ function loadToken() {
 function saveToken(token) {
   chrome.storage.local.set({ 'githubToken': token }, () => {
     console.log('GitHub token saved.');
+  });
+}
+
+/**
+ * Clear the GitHub token from Chrome storage.
+ */
+function clearToken() {
+  chrome.storage.local.remove('githubToken', () => {
+    document.getElementById('token').value = '';
+    console.log('GitHub token cleared.');
   });
 }
 


### PR DESCRIPTION
## Summary
- add a **Clear Token** button to the popup
- handle clearing the stored GitHub token
- document how to remove the saved token

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c839508832d920a6aa5346e9224