### PR TITLE
Add token clearing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
    - In the popup window, you can pick a commit from the dropdown or specify a branch name.
    - Click the **Summarize Repository** button to generate the summary.
    - Optionally, enter your GitHub Personal Access Token for higher rate limits.
+   - Use the **Clear Token** button to remove your stored token.
 
 4. **View the Summary**:
 

--- a/popup.html
+++ b/popup.html
@@ -407,6 +407,7 @@
   <div class="form-group" id="manualTokenGroup">
     <label for="token">GitHub Token (optional):</label>
     <input type="password" id="token" placeholder="GitHub Token">
+    <button id="clearTokenBtn" type="button">Clear Token</button>
   </div>
   <button id="googleSignInBtn" style="display:none;">Sign in with Google</button>
   <div class="form-group">

--- a/popup.js
+++ b/popup.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('preScanBtn').addEventListener('click', preScanRepo);
   document.getElementById('submitFeedbackBtn').addEventListener('click', submitFeedback);
   document.getElementById('copySummaryBtn').addEventListener('click', copySummaryToClipboard);
+  document.getElementById('clearTokenBtn').addEventListener('click', clearToken);
   const starBtn = document.getElementById('starRepoBtn');
   if (starBtn) starBtn.addEventListener('click', starRepo);
   const dismissBtn = document.getElementById('dismissStarPromptBtn');
@@ -72,6 +73,16 @@ function loadToken() {
 function saveToken(token) {
   chrome.storage.local.set({ 'githubToken': token }, () => {
     console.log('GitHub token saved.');
+  });
+}
+
+/**
+ * Remove the GitHub token from Chrome storage.
+ */
+function clearToken() {
+  chrome.storage.local.remove('githubToken', () => {
+    document.getElementById('token').value = '';
+    console.log('GitHub token cleared.');
   });
 }
 


### PR DESCRIPTION
## Summary
- add a **Clear Token** button in the popup so the stored token can be removed
- hook up a handler in `popup.js` to delete `githubToken` from storage
- document the clear token option in the README

## Testing
- `npm install --foreground-scripts`
- `npm test` *(fails: Waiting for selector `#summaryPreview` failed: 60000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_b_686f87061210832da6e96bc760bf3371