### PR TITLE
Improve error handling for skipped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@
 
 - **Large Repositories**:
   
-  - The extension may have difficulty processing very large repositories.
-  - Files larger than 100 KB are skipped to improve performance.
+- The extension may have difficulty processing very large repositories.
+- Files larger than 100 KB are skipped to improve performance.
+- If any files are skipped, their names are listed in the popup after summarization.
 
 - **Autoscroll Behavior**:
   

--- a/popup.html
+++ b/popup.html
@@ -446,6 +446,7 @@
 
   <div id="fileSize" class="info-display" style="display:none;"></div>
   <div id="tokenCount" class="info-display" style="display:none;"></div>
+  <div id="skippedFiles" class="info-display" style="display:none;"></div>
 
   <div id="summaryPreview" style="display:none;"></div>
 


### PR DESCRIPTION
## Summary
- display skipped files in the popup UI when fetching file contents fails
- show skipped files under Limitations in README

## Testing
- `npm install`
- `npm test` *(fails: TimeoutError: Waiting for selector `#summaryPreview` failed)*

------
https://chatgpt.com/codex/tasks/task_b_6870a3182c3c832d85e70f324f38f64f