### PR TITLE
Fix skipped files message handling

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -819,8 +819,8 @@ async function processRepo() {
           } else {
             message += ` (${displayList}, ...)`;
           }
-          skippedFilesEl.textContent = message;
-          skippedFilesEl.style.display = 'block';
+          console.warn(message);
+          skippedFilesEl.style.display = 'none';
         }
 
         // Show summary preview (first 100 chars and last 100 chars)


### PR DESCRIPTION
## Summary
- hide skipped file message in the popup
- log skipped file info to the console instead

## Testing
- `npm test` *(fails: Waiting for selector `#summaryPreview` failed)*

------
https://chatgpt.com/codex/tasks/task_b_687124ae5e0c832d82161bdf25d08c3d